### PR TITLE
Migrate envvars

### DIFF
--- a/addon/adapters/django-page.js
+++ b/addon/adapters/django-page.js
@@ -1,6 +1,6 @@
 import DS from 'ember-data';
 import fetch from 'fetch';
-import ENV from 'ember-get-config';
+import config from 'ember-get-config';
 import { isInDom } from 'nypr-django-for-ember/utils/alien-dom';
 import { canonicalize } from 'nypr-django-for-ember/services/script-loader';
 
@@ -16,13 +16,13 @@ export default DS.Adapter.extend({
     // we want.
     let url = '/';
     if (id === '/') {
-      if (ENV.betaTrials.isBetaSite) {
-        url = ENV.wnycBetaURL;
+      if (config.betaTrials.isBetaSite) {
+        url = config.wnycBetaURL;
       } else {
-        url = ENV.wnycURL;
+        url = config.webRoot;
       }
-    } else if (ENV.environment === 'test') {
-      url = ENV.wnycURL;
+    } else if (config.environment === 'test') {
+      url = config.webRoot;
     }
 
     return fetch(`${canonicalize(url)}${id === '/' ? '' : id}`, { headers: {'X-WNYC-EMBER':1}})

--- a/addon/components/django-page.js
+++ b/addon/components/django-page.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import service from 'ember-service/inject';
-import ENV from 'ember-get-config';
+import config from 'ember-get-config';
 import LegacySupportMixin from 'nypr-django-for-ember/mixins/legacy-support';
 import {
   isInDom,
@@ -10,7 +10,6 @@ import {
 import layout from '../templates/components/django-page';
 
 const { get, computed } = Ember;
-let { wnycAdminRoot } = ENV;
 
 export default Ember.Component.extend(LegacySupportMixin, {
   layout,
@@ -62,7 +61,7 @@ export default Ember.Component.extend(LegacySupportMixin, {
         this.set('showingOverlay', true);
 
         if (this.get('session.data.isStaff')) {
-          this.revealStaffLinks(this.$(), wnycAdminRoot);
+          this.revealStaffLinks(this.$(), config.adminRoot);
         }
         this.$().imagesLoaded().progress((i, image) => {
           Ember.run(() => {

--- a/addon/instance-initializers/link-handler.js
+++ b/addon/instance-initializers/link-handler.js
@@ -54,8 +54,8 @@ export function normalizeHref(node, base = location) {
   let isExternal = false;
   if (href.startsWith('#') || href.startsWith('mailto:')) {
     return {url, href, isExternal};
-  } else if (url.startsWith(config.wnycURL)) {
-    href = url.replace(config.wnycURL, '').replace(/^\//, '') || '/';
+  } else if (url.startsWith(config.webRoot)) {
+    href = url.replace(config.webRoot, '').replace(/^\//, '') || '/';
   } else if (!href.startsWith('/')) {
     href = '';
     isExternal = true;

--- a/addon/services/script-loader.js
+++ b/addon/services/script-loader.js
@@ -86,7 +86,7 @@ function scriptURL(tag) {
   if (url.indexOf(origin) === 0) {
     return url;
   } else {
-    return `${ENV.wnycAPI}/api/v1/dynamic-script-loader/?url=${encodeURIComponent(canonicalize(url))}`;
+    return `${ENV.wnycAPI}/v1/dynamic-script-loader/?url=${encodeURIComponent(canonicalize(url))}`;
   }
 }
 

--- a/addon/services/script-loader.js
+++ b/addon/services/script-loader.js
@@ -10,7 +10,7 @@ import fetch from 'fetch';
 import Ember from 'ember';
 import { mangleJavascript } from 'nypr-django-for-ember/utils/compat-hooks';
 const { Promise } = Ember.RSVP;
-import ENV from 'ember-get-config';
+import config from 'ember-get-config';
 
 export default Ember.Service.extend({
   asyncWriter: Ember.inject.service(),
@@ -81,12 +81,12 @@ export function canonicalize(url) {
 // In order to fetch all the scripts via XHR without tripping CORs
 // violations, we are proxying them through our own server.
 function scriptURL(tag) {
-  let origin = canonicalize(ENV.wnycURL);
+  let origin = canonicalize(config.webRoot);
   let url = canonicalize(tag.attributes.src.value);
   if (url.indexOf(origin) === 0) {
     return url;
   } else {
-    return `${ENV.wnycAPI}/v1/dynamic-script-loader/?url=${encodeURIComponent(canonicalize(url))}`;
+    return `${config.publisherAPI}/v1/dynamic-script-loader/?url=${encodeURIComponent(canonicalize(url))}`;
   }
 }
 

--- a/addon/utils/compat-hooks.js
+++ b/addon/utils/compat-hooks.js
@@ -87,5 +87,5 @@ export function retryFromServer(error, destinationPath) {
   if (response && (response.status === 404 || response.status === 500)) {
     throw error;
   }
-  assign(`${canonicalize(config.wnycURL)}/${destinationPath}`);
+  assign(`${canonicalize(config.webRoot)}/${destinationPath}`);
 }

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -35,7 +35,7 @@ module.exports = function(environment) {
   if (environment === 'test') {
     // Testem prefers this...
     ENV.locationType = 'none';
-    ENV.wnycURL = 'http://example.com';
+    ENV.webRoot = 'http://example.com';
 
     // keep test console output quieter
     ENV.APP.LOG_ACTIVE_GENERATION = false;

--- a/tests/unit/instance-initializers/link-handler-test.js
+++ b/tests/unit/instance-initializers/link-handler-test.js
@@ -1,9 +1,9 @@
 import { module, test } from 'qunit';
 import { shouldHandleLink, normalizeHref } from 'nypr-django-for-ember/instance-initializers/link-handler';
-import ENV from 'ember-get-config';
+import config from 'ember-get-config';
 import { canonicalize } from 'nypr-django-for-ember/services/script-loader';
-let { wnycURL } = ENV;
-wnycURL = canonicalize(wnycURL);
+let { webRoot } = config;
+webRoot = canonicalize(webRoot);
 
 // don't actually need to initialize the app, since we're just testing how the
 // link handler deals with incoming href values
@@ -34,7 +34,7 @@ test('shouldHandleLink for invalid links', function(assert) {
 
 test('shouldHandleLink for valid links', function(assert) {
   let a = document.createElement('a');
-  a.href = `${wnycURL}foo`;
+  a.href = `${webRoot}foo`;
   assert.ok(shouldHandleLink(a), 'should handle urls on this domain');
   a.href = '/foo';
   assert.ok(shouldHandleLink(a), 'should handle root-relative URLs');
@@ -45,27 +45,27 @@ test('normalizeHref should return expected values', function(assert) {
   a.href = '#foo';
   let ops = normalizeHref(a);
   assert.equal(ops.href, '#foo', 'return a hash for a hash');
-  ops = normalizeHref(a, wnycURL);
-  assert.equal(ops.href, '#foo', 'return a hash for a hash on wnycURL');
-  const oldUrl = wnycURL;
-  wnycURL += '?foo=bar';
-  ops = normalizeHref(a, wnycURL);
-  assert.equal(ops.href, '#foo', 'return a hash for a hash on wnycURL with a query string');
-  wnycURL = oldUrl;
+  ops = normalizeHref(a, webRoot);
+  assert.equal(ops.href, '#foo', 'return a hash for a hash on webRoot');
+  const oldUrl = webRoot;
+  webRoot += '?foo=bar';
+  ops = normalizeHref(a, webRoot);
+  assert.equal(ops.href, '#foo', 'return a hash for a hash on webRoot with a query string');
+  webRoot = oldUrl;
 
   a.href = `/foo/bar`;
-  ops = normalizeHref(a, wnycURL);
-  assert.deepEqual(ops, {url: `${wnycURL}foo/bar`, href: 'foo/bar', isExternal: false }, 'root-relative hrefs');
+  ops = normalizeHref(a, webRoot);
+  assert.deepEqual(ops, {url: `${webRoot}foo/bar`, href: 'foo/bar', isExternal: false }, 'root-relative hrefs');
 
-  a.href = `${wnycURL}foo/bar`;
-  ops = normalizeHref(a, wnycURL);
-  assert.deepEqual(ops, {url: `${wnycURL}foo/bar`, href: 'foo/bar', isExternal: false }, 'absolute urls');
+  a.href = `${webRoot}foo/bar`;
+  ops = normalizeHref(a, webRoot);
+  assert.deepEqual(ops, {url: `${webRoot}foo/bar`, href: 'foo/bar', isExternal: false }, 'absolute urls');
 
   a.href = `mailto:`;
-  ops = normalizeHref(a, wnycURL);
+  ops = normalizeHref(a, webRoot);
   assert.deepEqual(ops, {url: `mailto:`, href: 'mailto:', isExternal: false }, 'mailto:');
 
   a.href = `?foo=bar`;
-  ops = normalizeHref(a, wnycURL);
-  assert.deepEqual(ops, {url: `${wnycURL}?foo=bar`, href: '?foo=bar', isExternal: false }, '?foo=bar');
+  ops = normalizeHref(a, webRoot);
+  assert.deepEqual(ops, {url: `${webRoot}?foo=bar`, href: '?foo=bar', isExternal: false }, '?foo=bar');
 });


### PR DESCRIPTION
Updates to better organize envvars and remove the `wnyc` prefix. Also in the spirit of looking at Publisher as one of several microservices, this changes the value of the `wnycAPI` (renamed to `publisherAPI`) to include a path prefix. So the value will be `https://api.wnyc.org/api` instead of just `https://api.wnyc.org`.

Envvars renamed in this addon:
* `wnycAPI` -> `publisherAPI`
* `wnycAdminRoot` -> `adminRoot`
* `wnycURL` -> `webRoot`