### PR TITLE
Prevent link handler exceptions when metrics services don't exist

### DIFF
--- a/addon/instance-initializers/link-handler.js
+++ b/addon/instance-initializers/link-handler.js
@@ -7,6 +7,9 @@ function _trackEvent(data, instance) {
   let metrics = instance.lookup('service:metrics');
   // For future seekers looking for what handles these attributes, these are the strings you are looking for:
   // data-tracking-category, data-tracking-action, data-tracking-region, data-tracking-label
+  if (!metrics) {
+    return;
+  }
 
   let category = data.trackingCategory;
   let action   = data.trackingAction;
@@ -45,7 +48,9 @@ function _trackEvent(data, instance) {
 
 function _trackLegacyEvent(event, instance) {
   let legacyAnalytics = instance.lookup('service:legacy-analytics');
-  legacyAnalytics.dispatch(event);
+  if (legacyAnalytics) {
+    legacyAnalytics.dispatch(event);
+  }
 }
 
 export function normalizeHref(node, base = location) {


### PR DESCRIPTION
If these services don't exist in the client app, and a data-tracking or legacy analytics event is triggered, the link handler will fail and let the browser open the url, causing a page refresh.