### PR TITLE
treat URLs that start with a double slash as external

### DIFF
--- a/addon/instance-initializers/link-handler.js
+++ b/addon/instance-initializers/link-handler.js
@@ -65,7 +65,9 @@ export function normalizeHref(node, base = location) {
     return {url, href, isExternal};
   } else if (protocolFreeUrl.startsWith(protocolFreeWebRoot)) {
     href = protocolFreeUrl.replace(protocolFreeWebRoot, '').replace(/^\//, '') || '/';
-  } else if (!href.startsWith('/')) {
+  } else if (!href.startsWith('/') || href.startsWith('//')) {
+                                      // ^^^^ we shouldn't get here if href = current domain
+                                      // and if it doesn't we want to open in a new tab
     href = '';
     isExternal = true;
   }


### PR DESCRIPTION
… since the same domain will be treated as internal